### PR TITLE
Update const.py to update ASAIR_ROOT_URL due to SSL error

### DIFF
--- a/nexia/const.py
+++ b/nexia/const.py
@@ -9,7 +9,7 @@ BRAND_TRANE = "trane"
 
 NEXIA_ROOT_URL = "https://www.mynexia.com"
 NEXIA_IDENTIFIER = "com.tranetechnologies.nexia"
-ASAIR_ROOT_URL = "https://www.asairhome.com"
+ASAIR_ROOT_URL = "https://asairhome.com"
 ASAIR_IDENTIFIER = "com.tranetechnologies.asair"
 TRANE_ROOT_URL = "https://www.tranehome.com"
 TRANE_IDENTIFIER = "com.tranetechnologies.trane"


### PR DESCRIPTION
remove www from ASAIR_ROOT_URL to prevent [SSL: CERTIFICATE_VERIFY_FAILED] error: "Hostname mismatch, certificate is not valid for 'www.asairhome.com'"