### PR TITLE
Add pytest options to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,3 +33,7 @@ commands =
 
 [flake8]
 max-line-length = 120
+
+[pytest]
+asyncio_default_fixture_loop_scope = session
+asyncio_mode = auto


### PR DESCRIPTION
This pull request add 2 pytest options to reduce warnings emitted when tox runs.