### PR TITLE
Tooling changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ insert_final_newline = true
 charset = utf-8
 end_of_line = lf
 
+[*.json]
+indent_size = 2
+
 [*.bat]
 indent_style = tab
 end_of_line = crlf

--- a/pylintrc
+++ b/pylintrc
@@ -33,4 +33,4 @@ disable=
   missing-docstring,
 
 [EXCEPTIONS]
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception


### PR DESCRIPTION
Configure json editors to indent 2 spaces and
specify a supported pylint overgeneral-exceptions option.