### PR TITLE
Use async with statements to clean up response objects

### DIFF
--- a/delete_mobile_phones.py
+++ b/delete_mobile_phones.py
@@ -27,11 +27,11 @@ async def _runner(username, password, brand):
                 continue
 
             print("Delete phone id: ", phone_id)
-            response = await nexia_home.session.delete(
+            async with await nexia_home.session.delete(
                 "https://www.mynexia.com/mobile/phones/" + str(phone_id),
                 headers=nexia_home._api_key_headers(),  # noqa: SLF001
-            )
-            pprint.pprint(response)
+            ) as response:
+                pprint.pprint(response)
     finally:
         await session.close()
     return nexia_home

--- a/nexia/automation.py
+++ b/nexia/automation.py
@@ -45,7 +45,8 @@ class NexiaAutomation:
 
     async def activate(self) -> None:
         """Run the automation."""
-        await self._post_automation_json("activate", "")
+        async with await self._post_automation_json("activate", ""):
+            pass
 
     def _get_automation_key(self, key: str) -> Any:
         """Returns the automation value from the provided key in the automation's

--- a/nexia/thermostat.py
+++ b/nexia/thermostat.py
@@ -626,8 +626,8 @@ class NexiaThermostat:
             end_point=end_point,
             thermostat_id=self._thermostat_json["id"],
         )
-        response = await self._nexia_home.post_url(url, payload)
-        self.update_thermostat_json((await response.json())["result"])
+        async with await self._nexia_home.post_url(url, payload) as response:
+            self.update_thermostat_json((await response.json())["result"])
 
     def update_thermostat_json(self, thermostat_json):
         """Update with new json from the api."""

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -484,8 +484,8 @@ class NexiaThermostatZone:
         payload: dict[str, Any],
     ) -> None:
         url = self.API_MOBILE_ZONE_URL.format(end_point=end_point, zone_id=self.zone_id)
-        response = await self._nexia_home.post_url(url, payload)
-        self.update_zone_json((await response.json())["result"])
+        async with await self._nexia_home.post_url(url, payload) as response:
+            self.update_zone_json((await response.json())["result"])
 
     def update_zone_json(self, zone_json: dict[str, Any]) -> None:
         """Update with new json from the api."""

--- a/tests/fixtures/mobile_phones_response.json
+++ b/tests/fixtures/mobile_phones_response.json
@@ -1,0 +1,41 @@
+{
+  "success": true,
+  "error": null,
+  "result": {
+    "items": [
+      {
+        "phone_id": 5488863,
+        "name": "Lenovo2024",
+        "app_identifier": null,
+        "app_version": "6.0.0",
+        "platform": null,
+        "os_version": null,
+        "manufacturer": null,
+        "model": null,
+        "geofencing_enabled": false,
+        "is_browser": false,
+        "can_activate": true,
+        "is_activated": true,
+        "is_activated_by_activation_code": false,
+        "locale": "en_us",
+        "_links": {
+          "self": {
+            "href": "https://www.mynexia.com/mobile/phones/5488863"
+          },
+          "edit": {
+            "href": "https://www.mynexia.com/mobile/phones/5488863/edit"
+          }
+        }
+      }
+    ],
+    "_links": {
+      "self": {
+        "href": "https://www.mynexia.com/mobile/phones"
+      },
+      "child-schema": {
+        "href": "https://www.mynexia.com/mobile/phones/new"
+      }
+    },
+    "item_type": "application/vnd.nexia.phone+json"
+  }
+}

--- a/tests/fixtures/mobile_session.json
+++ b/tests/fixtures/mobile_session.json
@@ -1,0 +1,118 @@
+{
+  "success": true,
+  "error": null,
+  "result": {
+    "can_control_automations": true,
+    "can_manage_locks": true,
+    "can_view_videos": true,
+    "can_receive_notifications": true,
+    "is_activated_by_activation_code": 0,
+    "_links": {
+      "self": {
+        "href": "https://www.mynexia.com/mobile/session"
+      },
+      "child": [
+        {
+          "data": {
+            "id": 2582941,
+            "name": "My Home",
+            "postal_code": ""
+          },
+          "href": "https://www.mynexia.com/mobile/houses/2582941",
+          "type": "application/vnd.nexia.location+json"
+        },
+        {
+          "href": "https://www.mynexia.com/mobile/news",
+          "type": "application/vnd.nexia.collection+json",
+          "data": {
+            "items": [],
+            "_links": {
+              "self": {
+                "href": "https://www.mynexia.com/mobile/news?all_items=true"
+              }
+            },
+            "item_type": "application/vnd.nexia.news+json"
+          }
+        },
+        {
+          "href": "https://www.mynexia.com/mobile/geofences",
+          "type": "application/vnd.nexia.collection+json",
+          "data": {
+            "items": [],
+            "_links": {
+              "self": {
+                "href": "https://www.mynexia.com/mobile/geofences"
+              }
+            },
+            "item_type": "application/vnd.nexia.geofence+json"
+          }
+        },
+        {
+          "href": "https://www.mynexia.com/mobile/phones",
+          "type": "application/vnd.nexia.collection+json",
+          "data": {
+            "items": [
+              {
+                "phone_id": 5488863,
+                "name": "Lenovo2024",
+                "app_identifier": null,
+                "app_version": "6.0.0",
+                "platform": null,
+                "os_version": null,
+                "manufacturer": null,
+                "model": null,
+                "geofencing_enabled": false,
+                "is_browser": false,
+                "can_activate": true,
+                "is_activated": true,
+                "is_activated_by_activation_code": false,
+                "locale": "en_us",
+                "_links": {
+                  "self": {
+                    "href": "https://www.mynexia.com/mobile/phones/5488863"
+                  },
+                  "edit": {
+                    "href": "https://www.mynexia.com/mobile/phones/5488863/edit"
+                  }
+                }
+              }
+            ],
+            "_links": {
+              "self": {
+                "href": "https://www.mynexia.com/mobile/phones"
+              },
+              "child-schema": {
+                "href": "https://www.mynexia.com/mobile/phones/new"
+              }
+            },
+            "item_type": "application/vnd.nexia.phone+json"
+          }
+        },
+        {
+          "href": "https://www.mynexia.com/mobile/choices",
+          "type": "application/vnd.nexia.collection+json",
+          "data": {
+            "items": [],
+            "_links": {
+              "self": {
+                "href": "https://www.mynexia.com/mobile/choices"
+              }
+            },
+            "item_type": "application/vnd.nexia.choice+json"
+          }
+        }
+      ],
+      "parent": {
+        "href": "https://www.mynexia.com/mobile/accounts/2565505",
+        "type": "application/vnd.nexia.account+json"
+      },
+      "stream": {
+        "href": "wss://eventstreamer.mynexia.com/ws?authToken=cd2beadb55270311f4c20342387beaf5",
+        "type": "text/event-stream",
+        "data": {
+          "reconnect_href": "https://www.mynexia.com/mobile/event_stream_reservation"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/zone_response.json
+++ b/tests/fixtures/zone_response.json
@@ -1,0 +1,241 @@
+{
+  "success": true,
+  "error": null,
+  "result": {
+    "type": "xxl_zone",
+    "id": 85034552,
+    "name": "NativeZone",
+    "current_zone_mode": "HEAT",
+    "temperature": 69,
+    "setpoints": {
+      "heat": 69,
+      "cool": null
+    },
+    "operating_state": "",
+    "heating_setpoint": 69,
+    "cooling_setpoint": null,
+    "zone_status": "",
+    "settings": [],
+    "icon": {
+      "name": "thermostat",
+      "modifiers": ["temperature-69"]
+    },
+    "features": [
+      {
+        "name": "thermostat",
+        "scale": "f",
+        "temperature": 69,
+        "device_identifier": "XxlZone-85034552",
+        "status": "",
+        "status_icon": null,
+        "actions": {
+          "set_heat_setpoint": {
+            "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/setpoints"
+          }
+        },
+        "setpoint_delta": 3,
+        "setpoint_increment": 1.0,
+        "setpoint_heat_min": 55,
+        "setpoint_heat_max": 90,
+        "setpoint_cool_min": 60,
+        "setpoint_cool_max": 99,
+        "setpoint_heat": 69,
+        "system_status": "System Idle"
+      },
+      {
+        "name": "connection",
+        "signal_strength": "unknown",
+        "is_connected": true
+      },
+      {
+        "name": "dealer_contact_info",
+        "has_dealer_identifier": true,
+        "actions": {
+          "request_current_dealer_info": {
+            "method": "GET",
+            "href": "https://www.mynexia.com/mobile/dealers/7043919191"
+          },
+          "request_dealers_by_zip": {
+            "method": "POST",
+            "href": "https://www.mynexia.com/mobile/dealers/5378307/search"
+          }
+        }
+      },
+      {
+        "name": "thermostat_mode",
+        "label": "System Mode",
+        "value": "HEAT",
+        "display_value": "Heating",
+        "options": [
+          {
+            "id": "thermostat_mode",
+            "label": "System Mode",
+            "value": "thermostat_mode",
+            "header": true
+          },
+          {
+            "value": "AUTO",
+            "label": "Auto"
+          },
+          {
+            "value": "COOL",
+            "label": "Cooling"
+          },
+          {
+            "value": "HEAT",
+            "label": "Heating"
+          },
+          {
+            "value": "OFF",
+            "label": "Off"
+          }
+        ],
+        "actions": {
+          "update_thermostat_mode": {
+            "method": "POST",
+            "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/zone_mode"
+          }
+        }
+      },
+      {
+        "name": "thermostat_run_mode",
+        "label": "Run Mode",
+        "options": [
+          {
+            "id": "thermostat_run_mode",
+            "label": "Run Mode",
+            "value": "thermostat_run_mode",
+            "header": true
+          },
+          {
+            "id": "info_text",
+            "label": "Follow or override the schedule.",
+            "value": "info_text",
+            "info": true
+          },
+          {
+            "value": "permanent_hold",
+            "label": "Permanent Hold"
+          },
+          {
+            "value": "run_schedule",
+            "label": "Run Schedule"
+          }
+        ],
+        "value": "run_schedule",
+        "display_value": "Run Schedule",
+        "actions": {
+          "update_thermostat_run_mode": {
+            "method": "POST",
+            "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/run_mode"
+          }
+        }
+      },
+      {
+        "name": "room_iq_sensors",
+        "sensors": [
+          {
+            "id": 17687546,
+            "name": "Center",
+            "icon": {
+              "name": "room_iq_onboard",
+              "modifiers": []
+            },
+            "type": "thermostat",
+            "serial_number": "NativeIDTUniqueID",
+            "weight": 1.0,
+            "temperature": 69,
+            "temperature_valid": true,
+            "humidity": 22,
+            "humidity_valid": true,
+            "has_online": false,
+            "has_battery": false
+          },
+          {
+            "id": 17687549,
+            "name": "Upstairs",
+            "icon": {
+              "name": "room_iq_wireless",
+              "modifiers": []
+            },
+            "type": "930",
+            "serial_number": "2410R5C53X",
+            "weight": 0.0,
+            "temperature": 70,
+            "temperature_valid": true,
+            "humidity": 25,
+            "humidity_valid": true,
+            "has_online": true,
+            "connected": true,
+            "has_battery": true,
+            "battery_level": 93,
+            "battery_low": false,
+            "battery_valid": true
+          }
+        ],
+        "should_show": true,
+        "actions": {
+          "request_current_state": {
+            "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/request_current_sensor_state"
+          },
+          "update_active_sensors": {
+            "method": "POST",
+            "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/update_active_sensors"
+          }
+        }
+      },
+      {
+        "name": "preset_setpoints",
+        "presets": {
+          "1": {
+            "cool": 78,
+            "heat": 70
+          },
+          "2": {
+            "cool": 85,
+            "heat": 62
+          },
+          "3": {
+            "cool": 82,
+            "heat": 62
+          }
+        }
+      },
+      {
+        "name": "schedule",
+        "enabled": true,
+        "max_period_name_length": 10,
+        "setpoint_increment": 1.0,
+        "collection_url": "https://www.mynexia.com/mobile/schedules?device_identifier=XxlZone-85034552\u0026house_id=2582941",
+        "actions": {
+          "get_active_schedule": {
+            "href": "https://www.mynexia.com/mobile/thermostat_schedules/get_active_schedule?device_identifier=XxlZone-85034552",
+            "method": "POST"
+          },
+          "set_active_schedule": {
+            "href": "https://www.mynexia.com/mobile/thermostat_schedules/set_active_schedule?device_identifier=XxlZone-85034552",
+            "method": "POST"
+          },
+          "get_default_schedule": {
+            "href": "https://www.mynexia.com/mobile/thermostat_schedules/get_default_schedule?device_identifier=XxlZone-85034552",
+            "method": "GET"
+          },
+          "enable_scheduling": {
+            "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/scheduling_enabled",
+            "method": "POST",
+            "data": {
+              "value": true
+            }
+          }
+        },
+        "can_add_remove_periods": true,
+        "max_periods_per_day": 4
+      }
+    ],
+    "_links": {
+      "self": {
+        "href": "https://www.mynexia.com/mobile/xxl_zones/85034552"
+      }
+    }
+  }
+}

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -49,7 +49,7 @@ async def load_fixture(filename):
     return await loop.run_in_executor(None, _load_fixture, filename)
 
 
-async def test_login(aiohttp_session, mock_aioresponse):
+async def test_login(aiohttp_session, mock_aioresponse: aioresponses):
     """Test login sequence."""
     persist_file = Path("nexia_config_test.conf")
     nexia = NexiaHome(aiohttp_session, state_file=persist_file)
@@ -737,7 +737,7 @@ async def test_single_zone_system_off(aiohttp_session):
     assert zone.is_in_permanent_hold() is True
 
 
-async def test_automations(aiohttp_session, mock_aioresponse):
+async def test_automations(aiohttp_session, mock_aioresponse: aioresponses):
     """Get methods for an active thermostat."""
     nexia = NexiaHome(aiohttp_session)
     text = await load_fixture("mobile_houses_123456.json")

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -49,7 +49,9 @@ async def load_fixture(filename):
     return await loop.run_in_executor(None, _load_fixture, filename)
 
 
-async def test_login(aiohttp_session, mock_aioresponse: aioresponses):
+async def test_login(
+    aiohttp_session: aiohttp.ClientSession, mock_aioresponse: aioresponses
+) -> None:
     """Test login sequence."""
     persist_file = Path("nexia_config_test.conf")
     nexia = NexiaHome(aiohttp_session, state_file=persist_file)
@@ -154,7 +156,7 @@ async def test_login(aiohttp_session, mock_aioresponse: aioresponses):
     assert persist_file.exists() is False
 
 
-async def test_update(aiohttp_session):
+async def test_update(aiohttp_session: aiohttp.ClientSession) -> None:
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("mobile_houses_123456.json"))
     nexia.update_from_json(devices_json)
@@ -167,7 +169,7 @@ async def test_update(aiohttp_session):
     nexia.update_from_json(devices_json)
 
 
-async def test_idle_thermo(aiohttp_session):
+async def test_idle_thermo(aiohttp_session: aiohttp.ClientSession) -> None:
     """Get methods for an idle thermostat."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("mobile_houses_123456.json"))
@@ -206,7 +208,7 @@ async def test_idle_thermo(aiohttp_session):
     assert zone_ids == [83261002, 83261005, 83261008, 83261011]
 
 
-async def test_idle_thermo_issue_33758(mock_aioresponse: aioresponses):
+async def test_idle_thermo_issue_33758(mock_aioresponse: aioresponses) -> None:
     """Get methods for an idle thermostat."""
     aiohttp_session = aiohttp.ClientSession()
     nexia = NexiaHome(aiohttp_session)
@@ -261,7 +263,9 @@ async def test_idle_thermo_issue_33758(mock_aioresponse: aioresponses):
     await aiohttp_session.close()
 
 
-async def test_idle_thermo_issue_33968_thermostat_1690380(aiohttp_session):
+async def test_idle_thermo_issue_33968_thermostat_1690380(
+    aiohttp_session: aiohttp.ClientSession,
+) -> None:
     """Get methods for a cooling thermostat."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("mobile_house_issue_33968.json"))
@@ -416,7 +420,7 @@ async def test_xl824_1(aiohttp_session):
     assert zone_ids == [88888888]
 
 
-async def test_xl824_2(aiohttp_session):
+async def test_xl824_2(aiohttp_session: aiohttp.ClientSession) -> None:
     """Get methods for an xl824 thermostat."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("mobile_house_xl624.json"))
@@ -522,7 +526,9 @@ async def test_zone_issue_33968_zone_83037340(aiohttp_session):
     assert zone.is_in_permanent_hold() is True
 
 
-async def test_zone_issue_33968_zone_83037343(aiohttp_session):
+async def test_zone_issue_33968_zone_83037343(
+    aiohttp_session: aiohttp.ClientSession,
+) -> None:
     """Tests for nexia thermostat zone that is cooling."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("mobile_house_issue_33968.json"))
@@ -546,7 +552,7 @@ async def test_zone_issue_33968_zone_83037343(aiohttp_session):
     assert zone.is_in_permanent_hold() is True
 
 
-async def test_zone_issue_33758(aiohttp_session):
+async def test_zone_issue_33758(aiohttp_session: aiohttp.ClientSession) -> None:
     """Tests for nexia thermostat zone relieving air."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("mobile_house_issue_33758.json"))
@@ -662,7 +668,7 @@ async def test_xl824_idle(aiohttp_session):
     assert zone.is_in_permanent_hold() is True
 
 
-async def test_single_zone(aiohttp_session):
+async def test_single_zone(aiohttp_session: aiohttp.ClientSession) -> None:
     """Test thermostat with only a single (Native) zone."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("single_zone_xl1050.json"))
@@ -686,7 +692,7 @@ async def test_single_zone(aiohttp_session):
     assert zone.is_in_permanent_hold() is True
 
 
-async def test_single_zone_system_off(aiohttp_session):
+async def test_single_zone_system_off(aiohttp_session: aiohttp.ClientSession) -> None:
     """Test thermostat with only a single (Native) zone."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("single_zone_xl1050_system_off.json"))
@@ -737,7 +743,9 @@ async def test_single_zone_system_off(aiohttp_session):
     assert zone.is_in_permanent_hold() is True
 
 
-async def test_automations(aiohttp_session, mock_aioresponse: aioresponses):
+async def test_automations(
+    aiohttp_session: aiohttp.ClientSession, mock_aioresponse: aioresponses
+) -> None:
     """Get methods for an active thermostat."""
     nexia = NexiaHome(aiohttp_session)
     text = await load_fixture("mobile_houses_123456.json")
@@ -781,7 +789,7 @@ async def test_automations(aiohttp_session, mock_aioresponse: aioresponses):
     await automation_one.activate()
 
 
-async def test_x850_grouped(aiohttp_session):
+async def test_x850_grouped(aiohttp_session: aiohttp.ClientSession) -> None:
     """Get methods for an xl850 grouped thermostat."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("grouped_xl850.json"))
@@ -830,7 +838,7 @@ async def test_x850_grouped(aiohttp_session):
     assert zone.is_in_permanent_hold() is True
 
 
-async def test_issue_79891(aiohttp_session):
+async def test_issue_79891(aiohttp_session: aiohttp.ClientSession) -> None:
     """Get methods issue 79891 thermostat.
 
     https://github.com/home-assistant/core/issues/79891
@@ -923,7 +931,7 @@ async def test_issue_79891(aiohttp_session):
     assert zone.is_in_permanent_hold() is False
 
 
-async def test_new_xl1050(aiohttp_session):
+async def test_new_xl1050(aiohttp_session: aiohttp.ClientSession) -> None:
     """Get with a new xl1050."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("xl1050.json"))
@@ -973,7 +981,7 @@ async def test_new_xl1050(aiohttp_session):
     assert zone.is_in_permanent_hold() is False
 
 
-async def test_new_xl824(aiohttp_session):
+async def test_new_xl824(aiohttp_session: aiohttp.ClientSession) -> None:
     """Get with a new xl824."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("xl824.json"))
@@ -1024,7 +1032,7 @@ async def test_new_xl824(aiohttp_session):
     assert zone.is_in_permanent_hold() is True
 
 
-async def test_system_offline(aiohttp_session):
+async def test_system_offline(aiohttp_session: aiohttp.ClientSession) -> None:
     """Get a system offline."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("system_offline.json"))
@@ -1075,7 +1083,7 @@ async def test_system_offline(aiohttp_session):
     assert zone.is_in_permanent_hold() is True
 
 
-async def test_emergency_heat(aiohttp_session):
+async def test_emergency_heat(aiohttp_session: aiohttp.ClientSession) -> None:
     """Test emergency heat."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("eme_heat.json"))


### PR DESCRIPTION
This pull request closes up the aiohttp response objects at runtime. These objects are async context managers, so `async with` statements are used.