### PR TITLE
Remove input checking and rely on clamped values

### DIFF
--- a/nexia/thermostat.py
+++ b/nexia/thermostat.py
@@ -595,29 +595,6 @@ class NexiaThermostat:
         dehumidify_setpoint = find_humidity_setpoint(dehumidify_setpoint)
         humidify_setpoint = find_humidity_setpoint(humidify_setpoint)
 
-        # # Check inputs
-        # if (dehumidify_supported and humidify_supported) and not (
-        #     (min_humidify <= humidify_setpoint <= max_humidify)
-        #     and (min_dehumidify <= dehumidify_setpoint <= max_dehumidify)
-        # ):
-        #     raise ValueError(
-        #         f"Setpoints must be between minimum and maximum -"
-        #         f" Dehumidify: ({min_dehumidify} - {max_dehumidify}),"
-        #         f" Humidify: ({min_humidify} - {max_humidify})."
-        #     )
-        # if dehumidify_supported and not (
-        #     min_dehumidify <= dehumidify_setpoint <= max_dehumidify
-        # ):
-        #     raise ValueError(
-        #         f"dehumidify_setpoint must be between ({min_dehumidify} - {max_dehumidify})",
-        #     )
-        # if humidify_supported and not (
-        #     min_humidify <= humidify_setpoint <= max_humidify
-        # ):
-        #     raise ValueError(
-        #         f"humidify_setpoint must be between ({min_humidify} - {max_humidify})",
-        #     )
-
         if (
             dehumidify_supported
             and (
@@ -645,7 +622,7 @@ class NexiaThermostat:
         ):
             await self._post_and_update_thermostat_json(
                 ThermostatEndpoint.HUMIDIFY,
-                {"value": str(humidify_setpoint)},
+                {"value": str(clamped_humidify_setpoint)},
             )
 
     async def set_dehumidify_setpoint(self, dehumidify_setpoint: float) -> None:

--- a/nexia/thermostat.py
+++ b/nexia/thermostat.py
@@ -595,28 +595,28 @@ class NexiaThermostat:
         dehumidify_setpoint = find_humidity_setpoint(dehumidify_setpoint)
         humidify_setpoint = find_humidity_setpoint(humidify_setpoint)
 
-        # Check inputs
-        if (dehumidify_supported and humidify_supported) and not (
-            (min_humidify <= humidify_setpoint <= max_humidify)
-            and (min_dehumidify <= dehumidify_setpoint <= max_dehumidify)
-        ):
-            raise ValueError(
-                f"Setpoints must be between minimum and maximum -"
-                f" Dehumidify: ({min_dehumidify} - {max_dehumidify}),"
-                f" Humidify: ({min_humidify} - {max_humidify})."
-            )
-        if dehumidify_supported and not (
-            min_dehumidify <= dehumidify_setpoint <= max_dehumidify
-        ):
-            raise ValueError(
-                f"dehumidify_setpoint must be between ({min_dehumidify} - {max_dehumidify})",
-            )
-        if humidify_supported and not (
-            min_humidify <= humidify_setpoint <= max_humidify
-        ):
-            raise ValueError(
-                f"humidify_setpoint must be between ({min_humidify} - {max_humidify})",
-            )
+        # # Check inputs
+        # if (dehumidify_supported and humidify_supported) and not (
+        #     (min_humidify <= humidify_setpoint <= max_humidify)
+        #     and (min_dehumidify <= dehumidify_setpoint <= max_dehumidify)
+        # ):
+        #     raise ValueError(
+        #         f"Setpoints must be between minimum and maximum -"
+        #         f" Dehumidify: ({min_dehumidify} - {max_dehumidify}),"
+        #         f" Humidify: ({min_humidify} - {max_humidify})."
+        #     )
+        # if dehumidify_supported and not (
+        #     min_dehumidify <= dehumidify_setpoint <= max_dehumidify
+        # ):
+        #     raise ValueError(
+        #         f"dehumidify_setpoint must be between ({min_dehumidify} - {max_dehumidify})",
+        #     )
+        # if humidify_supported and not (
+        #     min_humidify <= humidify_setpoint <= max_humidify
+        # ):
+        #     raise ValueError(
+        #         f"humidify_setpoint must be between ({min_humidify} - {max_humidify})",
+        #     )
 
         if (
             dehumidify_supported

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1232,15 +1232,6 @@ async def test_humidity_and_fan_mode(
         )
     )
 
-    # Attempt to set a value out of setpoint limits should raise ValueError
-    with pytest.raises(
-        ValueError,
-        match="Setpoints must be between minimum and maximum.*",
-    ):
-        await thermostat.set_humidity_setpoints(
-            humidify_setpoint=0.60, dehumidify_setpoint=0.60
-        )
-
     # Attempting to set to different value should trigger an API call
     await thermostat.set_humidity_setpoints(
         humidify_setpoint=0.15, dehumidify_setpoint=0.60


### PR DESCRIPTION
After adding `clamp_to_predefined_values` input checking is no longer necessary and potentially creates complexities with the new logic to set two values at the same time. Also, fixed an error.