### PR TITLE
Add service to specify which sensors to include in the zone average

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ By connecting this component, you will have access to all thermostats and zones 
 
 The Nexia Thermostat supports the following key concepts.
 
-#### Sensors
+#### RoomIQ Sensors
 
 You can obtain sensor details in a Nexia Thermostat environment.
 The sensor data loaded during Nexia Home update are often out of date.
@@ -33,6 +33,8 @@ If no such service is desired,
 the Nexia Thermostat service `refresh_thermostat_data` is provided to refresh instance data.
 The Nexia Thermostat Zone service `get_sensors` is provided to obtain these
 sensor data in a list of sensor detail data objects of type NexiaSensor.
+You can specify which RoomIQ sensors to include in the zone average via
+the Nexia Thermostat Zone service `select_room_iq_sensors`.
 
 ## Attributes
 
@@ -430,13 +432,27 @@ Part of the `nexia.` services. Sets the humidify setpoint. This is a system-wide
 ## NexiaThermostatZone Services
 
 The following services are provided by the Nexia Thermostat Zone:
-`get_sensors`, `load_current_sensor_state`
+`get_sensors`, `select_room_iq_sensors`, `load_current_sensor_state`
 
 ### Service `get_sensors`
 
 Get the sensor detail data objects from this zone instance.
 Provides a list of sensor detail data objects available in this zone.
 No arguments are passed to this service.
+
+### Service `select_room_iq_sensors`
+
+Specify which RoomIQ sensors to include in the zone average.
+RoomIQ sensors not given to this service are not included.
+You specify which sensors to include by supplying a collection of RoomIQ sensor identifiers.
+Valid identifiers come from the sensor detail data objects returned from `get_sensors`.
+This service returns a bool indicating if it completed successfully.
+
+| Service data attribute | Optional | Default | Description                                                      |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------- |
+| `active_sensor_ids`    | no       |         | collection of RoomIQ sensor identifiers to form the zone average |
+| `polling_delay`        | yes      | 5.0     | seconds to wait before each polling attempt                      |
+| `max_polls`            | yes      | 8       | maximum number of times to poll for completion                   |
 
 ### Service `load_current_sensor_state`
 

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import math
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, Literal
@@ -336,12 +338,16 @@ class NexiaThermostatZone:
             return True
         return run_mode["current_value"] in HOLD_VALUES_SET
 
+    def _get_room_iq_sensors_json(self) -> list[dict[str, Any]]:
+        """Get our list of RoomIQ sensor json dictionaries, or raise KeyError."""
+        return self._get_zone_features("room_iq_sensors")["sensors"]
+
     def get_sensors(self) -> list[NexiaSensor]:
         """Get the sensor detail data objects from this instance
         :return: list of sensor detail data objects
         """
         try:
-            sensors_json = self._get_zone_features("room_iq_sensors")["sensors"]
+            sensors_json = self._get_room_iq_sensors_json()
 
             return [NexiaSensor.from_json(sensor_json) for sensor_json in sensors_json]
         except KeyError:
@@ -540,6 +546,48 @@ class NexiaThermostatZone:
                 f'Invalid mode "{mode}". Select one of the following: {OPERATION_MODES}',
             )
 
+    async def select_room_iq_sensors(
+        self, active_sensor_ids: Iterable[int], polling_delay=5.0, max_polls=8
+    ) -> bool:
+        """Select which RoomIQ sensors are included in the zone average.
+        :param active_sensor_ids: collection of RoomIQ sensor identifiers to form the zone average
+        :param polling_delay: seconds to wait before each polling attempt
+        :param max_polls: maximum number of times to poll for completion
+        :return: bool indicating completed
+        """
+        if not active_sensor_ids:
+            raise ValueError(
+                f"At least one sensor is required when selecting"
+                f" RoomIQ sensors, but got `{active_sensor_ids!r}`"
+            )
+        active_sensor_id_set = set(active_sensor_ids)
+        try:
+            request_json = copy.deepcopy(self._get_room_iq_sensors_json())
+        except KeyError as e:
+            raise AttributeError(
+                f"RoomIQ sensors not supported in zone {self.get_name()}"
+            ) from e
+
+        known_sensor_ids = [sensor["id"] for sensor in request_json]
+        for sensor_id in active_sensor_id_set:
+            if sensor_id not in known_sensor_ids:
+                raise ValueError(f"RoomIQ sensor with id {sensor_id} not present")
+
+        weight = 1 / len(active_sensor_id_set)
+        for sensor in request_json:
+            sensor["weight"] = weight if sensor["id"] in active_sensor_id_set else 0.0
+
+        update_active_sensors = self.API_MOBILE_ZONE_URL.format(
+            end_point="update_active_sensors", zone_id=self.zone_id
+        )
+        return await self._post_and_await_async_completion(
+            update_active_sensors,
+            {"updated_sensors": request_json},
+            "selecting active sensors",
+            polling_delay,
+            max_polls,
+        )
+
     async def load_current_sensor_state(self, polling_delay=5.0, max_polls=8) -> bool:
         """Load the current state of a zone's sensors into the physical thermostat.
         :param polling_delay: seconds to wait before each polling attempt
@@ -549,8 +597,27 @@ class NexiaThermostatZone:
         req_cur_state = self.API_MOBILE_ZONE_URL.format(
             end_point="request_current_sensor_state", zone_id=self.zone_id
         )
+        return await self._post_and_await_async_completion(
+            req_cur_state, {}, "loading current sensor state", polling_delay, max_polls
+        )
 
-        async with await self._nexia_home.post_url(req_cur_state, {}) as response:
+    async def _post_and_await_async_completion(
+        self,
+        request_url: str,
+        json_data: dict,
+        target: str,
+        polling_delay: float,
+        max_polls: int,
+    ) -> bool:
+        """Post a request that returns an asynchronous url to poll for completion.
+        :param request_url: url for service being requested
+        :param json_data: json data to be the request payload
+        :param target: description of what is being accomplished
+        :param polling_delay: seconds to wait before each polling attempt
+        :param max_polls: maximum number of times to poll for completion
+        :return: bool indicating completed
+        """
+        async with await self._nexia_home.post_url(request_url, json_data) as response:
             # The polling path in the response has the form:
             #   https://www.mynexia.com/backstage/announcements/<48-hex-digits>
             polling_url = self._nexia_home.resolve_url(
@@ -567,14 +634,12 @@ class NexiaThermostatZone:
                 status = json.loads(payload)["status"]
 
                 if status != "success":
-                    _LOGGER.error(
-                        "Unexpected status [%s] loading current sensor state", status
-                    )
+                    _LOGGER.error("Unexpected status [%s] %s", status, target)
                 return True
             attempts -= 1
         # end while waiting for status
 
-        _LOGGER.error("Gave up waiting for current sensor state")
+        _LOGGER.error("Gave up waiting while %s", target)
         return False
 
     def round_temp(self, temperature: float) -> float:


### PR DESCRIPTION
Fixes #39 by enabling the nexia library to see and specify which RoomIQ sensors to include in a zone average.
With this, a dependent PR can be implemented in the `home-assistant/core` nexia integration to select RoomIQ sensors.