### PR TITLE
Swap default to log http responses until disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,12 +295,12 @@ The following attribute is provided by the Nexia Home:
 
 An instance attribute of NexiaHome that controls logging http response text.
 This can be True or False.
-It is initialized to False and you can change it to
-True when you want to collect http response text in your logs.
+It is initialized to True and you can change it to False
+when you want to stop collecting http response text in your logs.
 
-| Attribute type | Description              |
-| -------------- | ------------------------ |
-| Boolean        | response logging control |
+| Attribute type | Default | Description              |
+| -------------- | ------- | ------------------------ |
+| Boolean        | True    | response logging control |
 
 ## Services
 

--- a/nexia/home.py
+++ b/nexia/home.py
@@ -113,7 +113,7 @@ class NexiaHome:
         self._uuid = None
         self.session = session
         self.loop = asyncio.get_running_loop()
-        self.log_response = False
+        self.log_response = True
 
     @property
     def API_MOBILE_PHONE_URL(self) -> str:  # pylint: disable=invalid-name
@@ -191,22 +191,23 @@ class NexiaHome:
         return headers
 
     async def _debug_log_resp(self, response: aiohttp.ClientResponse) -> None:
-        if self.log_response:
-            _LOGGER.debug(
-                "%s: Response from url %s: status: %s:\n%s",
-                response.method,
-                response.url,
-                response.status,
-                (await response.text()).strip(),
-            )
-        else:
-            _LOGGER.debug(
-                "%s: Response from url %s: status: %s: %s",
-                response.method,
-                response.url,
-                response.status,
-                response.content,
-            )
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            if self.log_response:
+                _LOGGER.debug(
+                    "%s: Response from url %s: status: %s:\n%s",
+                    response.method,
+                    response.url,
+                    response.status,
+                    (await response.text()).strip(),
+                )
+            else:
+                _LOGGER.debug(
+                    "%s: Response from url %s: status: %s: %s",
+                    response.method,
+                    response.url,
+                    response.status,
+                    response.content,
+                )
 
     async def post_url(
         self, request_url: URL | str, payload: dict

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 import os
 from os.path import dirname
 from pathlib import Path
@@ -1299,6 +1300,7 @@ async def test_sensor_access(
     """Test sensor access methods."""
     persist_file = Path("nexia_config_test.conf")
     nexia = NexiaHome(aiohttp_session, house_id=2582941, state_file=persist_file)
+    logging.getLogger("nexia").setLevel(logging.DEBUG)
     mock_aioresponse.post(
         "https://www.mynexia.com/mobile/accounts/sign_in",
         payload={
@@ -1362,8 +1364,8 @@ async def test_sensor_access(
     assert sensor.battery_low is False
     assert sensor.battery_valid is True
 
-    # execute log response code path
-    nexia.log_response = True
+    # execute no log response code path
+    nexia.log_response = False
 
     # execute no completion code path
     mock_aioresponse.post(


### PR DESCRIPTION
The log_response instance attribute of NexiaHome defaults to True with this change. Callers that make no changes will get http response text in their debug logs.
To avoid always running `await response.text()` , this code is conditioned on debug logging being enabled.