### PR TITLE
Add zone service to get sensor by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ If no such service is desired,
 the Nexia Thermostat service `refresh_thermostat_data` is provided to refresh instance data.
 The Nexia Thermostat Zone service `get_sensors` is provided to obtain these
 sensor data in a list of sensor detail data objects of type NexiaSensor.
+To get a specific sensor detail data object,
+the Nexia Thermostat Zone service `get_sensor_by_id` is provided.
 You can specify which RoomIQ sensors to include in the zone average via
 the Nexia Thermostat Zone service `select_room_iq_sensors`.
 
@@ -432,13 +434,23 @@ Part of the `nexia.` services. Sets the humidify setpoint. This is a system-wide
 ## NexiaThermostatZone Services
 
 The following services are provided by the Nexia Thermostat Zone:
-`get_sensors`, `select_room_iq_sensors`, `load_current_sensor_state`
+`get_sensors`, `get_sensor_by_id`, `select_room_iq_sensors`, `load_current_sensor_state`
 
 ### Service `get_sensors`
 
 Get the sensor detail data objects from this zone instance.
 Provides a list of sensor detail data objects available in this zone.
 No arguments are passed to this service.
+
+### Service `get_sensor_by_id`
+
+Get a RoomIQ sensor detail data object by its sensor identifier.
+Valid identifiers come from the sensor detail data objects returned from `get_sensors`.
+Provides a specific sensor detail data object from this zone instance.
+
+| Service data attribute | Optional | Description                        |
+| ---------------------- | -------- | ---------------------------------- |
+| `sensor_id`            | no       | identifier of RoomIQ sensor to get |
 
 ### Service `select_room_iq_sensors`
 

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -706,6 +706,12 @@ async def test_single_zone(aiohttp_session: aiohttp.ClientSession) -> None:
     ):
         await zone.select_room_iq_sensors([76543210])
 
+    with pytest.raises(
+        AttributeError,
+        match="RoomIQ sensors not supported in zone Thermostat 1 NativeZone",
+    ):
+        zone.get_sensor_by_id(87654321)
+
 
 async def test_single_zone_system_off(aiohttp_session: aiohttp.ClientSession) -> None:
     """Test thermostat with only a single (Native) zone."""
@@ -1348,6 +1354,29 @@ async def test_sensor_access(
     assert sensor.battery_valid is None
 
     sensor = sensors[1]
+    assert sensor.id == 17687549
+    assert sensor.name == "Upstairs"
+    assert sensor.type == "930"
+    assert sensor.serial_number == "2410R5C53X"
+    assert sensor.weight == 0.5
+    assert sensor.temperature == 69
+    assert sensor.temperature_valid is True
+    assert sensor.humidity == 32
+    assert sensor.humidity_valid is True
+    assert sensor.has_online is True
+    assert sensor.connected is True
+    assert sensor.has_battery is True
+    assert sensor.battery_level == 95
+    assert sensor.battery_low is False
+    assert sensor.battery_valid is True
+
+    with pytest.raises(
+        KeyError,
+        match=r"Sensor ID \(87654321\) not found, valid IDs: 17687546, 17687549",
+    ):
+        zone.get_sensor_by_id(87654321)
+
+    sensor = zone.get_sensor_by_id(17687549)
     assert sensor.id == 17687549
     assert sensor.name == "Upstairs"
     assert sensor.type == "930"


### PR DESCRIPTION
Provide a new service API to get a sensor for a specific sensor id. This will streamline implementation of Home Assistant entities that need a specific sensor.