### PR TITLE
Add service get_active_sensor_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ To get a specific sensor detail data object,
 the Nexia Thermostat Zone service `get_sensor_by_id` is provided.
 You can specify which RoomIQ sensors to include in the zone average via
 the Nexia Thermostat Zone service `select_room_iq_sensors`.
+You can see which RoomIQ sensors are included in the zone average via
+the Nexia Thermostat Zone service `get_active_sensor_ids`.
 
 ## Attributes
 
@@ -434,12 +436,19 @@ Part of the `nexia.` services. Sets the humidify setpoint. This is a system-wide
 ## NexiaThermostatZone Services
 
 The following services are provided by the Nexia Thermostat Zone:
-`get_sensors`, `get_sensor_by_id`, `select_room_iq_sensors`, `load_current_sensor_state`
+`get_sensors`, `get_active_sensor_ids`, `get_sensor_by_id`,
+`select_room_iq_sensors`, `load_current_sensor_state`
 
 ### Service `get_sensors`
 
 Get the sensor detail data objects from this zone instance.
 Provides a list of sensor detail data objects available in this zone.
+No arguments are passed to this service.
+
+### Service `get_active_sensor_ids`
+
+Get the set of RoomIQ sensor ids included in the zone average.
+Provides a set of active RoomIQ sensor ids.
 No arguments are passed to this service.
 
 ### Service `get_sensor_by_id`

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -359,6 +359,18 @@ class NexiaThermostatZone:
             # our json has no sensors
             return []
 
+    def get_active_sensor_ids(self) -> set[int]:
+        """Get the set of RoomIQ sensor ids included in the zone average.
+
+        :return: set of active RoomIQ sensor ids.
+        """
+        try:
+            sensors_json = self._get_room_iq_sensors_json()
+
+            return {sensor["id"] for sensor in sensors_json if sensor["weight"] > 0.0}
+        except AttributeError:
+            return set()
+
     def get_sensor_by_id(self, sensor_id: int) -> NexiaSensor:
         """Get a RoomIQ sensor detail data object by its sensor id.
         :param sensor_id: identifier of RoomIQ sensor to get

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -700,6 +700,7 @@ async def test_single_zone(aiohttp_session: aiohttp.ClientSession) -> None:
     # No sensors
     sensors = zone.get_sensors()
     assert len(sensors) == 0
+    assert len(zone.get_active_sensor_ids()) == 0
     with pytest.raises(
         AttributeError,
         match="RoomIQ sensors not supported in zone Thermostat 1 NativeZone",
@@ -1369,6 +1370,8 @@ async def test_sensor_access(
     assert sensor.battery_level == 95
     assert sensor.battery_low is False
     assert sensor.battery_valid is True
+
+    assert zone.get_active_sensor_ids() == {17687546, 17687549}
 
     with pytest.raises(
         KeyError,


### PR DESCRIPTION
Add service to see which RoomIQ sensors are included in the zone average.
It returns the set of RoomIQ sensor ids so included.