### PR TITLE
Update sensor selection when starting trigger sequence

### DIFF
--- a/nexia/roomiq.py
+++ b/nexia/roomiq.py
@@ -41,15 +41,21 @@ class NexiaRoomIQHarmonizer:
 
     def trigger_add_sensor(self, sensor_id: int) -> None:
         """Trigger selecting the specified sensor for the zone."""
-        self._request_time = self._loop.time()
+        self._start_trigger()
         self.selected_sensor_ids.add(sensor_id)
         self._single_shot.reset_delayed_action_trigger()
 
     def trigger_remove_sensor(self, sensor_id: int) -> None:
         """Trigger removing the specified sensor from the zone selection."""
-        self._request_time = self._loop.time()
+        self._start_trigger()
         self.selected_sensor_ids.discard(sensor_id)
         self._single_shot.reset_delayed_action_trigger()
+
+    def _start_trigger(self):
+        """Start a trigger sequence. If none yet pending, update sensor selection."""
+        if self._request_time is None:
+            self.selected_sensor_ids = self._zone.get_active_sensor_ids()
+        self._request_time = self._loop.time()
 
     async def _select_sensors(self) -> None:
         """Select the RoomIQ sensors now that the delay has completed.
@@ -60,7 +66,6 @@ class NexiaRoomIQHarmonizer:
 
         # At least one sensor must be selected and the request should differ.
         if not self.selected_sensor_ids or self.selected_sensor_ids == active_sensors:
-            self.selected_sensor_ids = active_sensors
             self._request_time = None
             self._signal_updated()
             return

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1920,7 +1920,6 @@ async def test_sensor_multi_select(aiohttp_session: aiohttp.ClientSession) -> No
 
     # Wait some time to run no selected sensor case.
     await asyncio.sleep(0.02)
-    assert harm.selected_sensor_ids == {17687546, 17687549}
     assert signal_updated.call_count == 1
     assert harm.request_pending() is False
 
@@ -1933,7 +1932,6 @@ async def test_sensor_multi_select(aiohttp_session: aiohttp.ClientSession) -> No
     # Wait some time to run normal selected sensor case.
     assert async_request_refetch.call_count == 0
     await asyncio.sleep(0.02)
-    assert harm.selected_sensor_ids == {17687546}
     assert async_request_refetch.call_count == 1
     assert signal_updated.call_count == 2
     assert harm.request_pending() is False


### PR DESCRIPTION
When starting a trigger sequence in a NexiaRoomIQHarmonizer, if no requests are yet pending, update sensor selection from the zone's json data.