### PR TITLE
Fix aiohttp lib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp>=3.8.0
+aiohttp>=3.13.5
 orjson>=3.7.2
 propcache>=0.2.0

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -5,5 +5,6 @@ pylint
 pytest
 pytest-asyncio
 pytest-cov
+aiohttp<3.14
 aioresponses
 tox


### PR DESCRIPTION
### Proposed changes
- limit the aiohttp to < 3.14 when testing
### Why
The CI workflow pytest started failing with:
`TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'`

This error is caused by a breaking change in `aiohttp` 3.14.x, which recently refactored ClientResponse.__init__ and made the `stream_writer` argument mandatory. No available version of aioresponses passes this parameter, causing the tests to fail.

I based this on the dependabot branch for `aiohttp` since it is closely related.