### PR TITLE
build: drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     rev: v3.21.2
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version="2.11.1"
 license = { text = "Apache-2.0" }
 description = "Python library for connecting to nexia"
 authors = [{ name = "J. Nick Koston", email = "nick@koston.org" }]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["nexia"]
 classifiers=[
     "Development Status :: 2 - Pre-Alpha",
@@ -16,7 +16,6 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, lint
+envlist = py310, py311, lint
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
### Proposed changes
Drop Python 3.9; set the minimum supported version to 3.10 in pyproject, the CI matrix, tox, and the pyupgrade target.

### Why
Prelim for #210; the poetry migration there assumes 3.10 or newer, so dropping 3.9 first keeps that PR focused on the tooling change.