### PR TITLE
ci: use the release environment for trusted publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
         with:
           no_operation_mode: true
 
-  # Real release, only on master. The pypi environment and write/OIDC
+  # Real release, only on master. The release environment and write/OIDC
   # permissions are scoped to this job so they never apply to PR runs.
   release:
     if: github.ref_name == 'master'
@@ -106,7 +106,7 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: release
       url: https://pypi.org/p/nexia
     concurrency:
       group: release-${{ github.ref }}


### PR DESCRIPTION
### Proposed changes
Point the release job at the release GitHub environment instead of pypi, matching the PyPI trusted publisher which is now configured for the release environment.

### Why
The trusted publisher entry on PyPI was switched to the release environment; without this the OIDC token from the publish step would not match and the upload would be rejected. The release environment must exist on the repo with the trusted publishing setup.