### PR TITLE
feat: enable RoomIQ sensor monitor registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following service is provided by the Nexia Home:
 
 ### Service `any_room_iq_monitors`
 
-Return True when any RoomIQ sensor monitors are present.
+Return True when any RoomIQ sensor monitors are registered.
 No arguments are passed to this service.
 
 ## Thermostat Attributes
@@ -507,28 +507,28 @@ This service returns a bool indicating if it completed successfully.
 
 ### Service `add_room_iq_monitor`
 
-Add a RoomIQ sensor monitor to this zone's collection.
-A RoomIQ sensor monitor lets the Nexia library know there is a party
-interested in seeing current states of this zone's RoomIQ sensors.
-If no monitors are added, updates don't load current RoomIQ sensor states.
+Register a subscriber for this zone's RoomIQ sensor state updates.
+When at least one monitor is registered, each Nexia Home update will
+also fetch the current RoomIQ sensor states for this zone, adding
+5–40 seconds of latency and additional network traffic.
 
-| Service data attribute | Optional | Default | Description                                           |
-| ---------------------- | -------- | ------- | ----------------------------------------------------- |
-| `monitor_id`           | no       |         | string for the interested party (unique in this zone) |
+| Service data attribute | Optional | Default | Description                                         |
+| ---------------------- | -------- | ------- | --------------------------------------------------- |
+| `monitor_id`           | no       |         | identifier for the subscriber (unique in this zone) |
 
 ### Service `remove_room_iq_monitor`
 
-Remove a RoomIQ sensor monitor from this zone's collection.
-This tells the Nexia library the specified party is no longer
-interested in seeing current states of this zone's RoomIQ sensors.
+Unregister a subscriber for this zone's RoomIQ sensor state updates.
+This tells the Nexia library the specified subscriber is no longer
+interested in current states of this zone's RoomIQ sensors.
 
-| Service data attribute | Optional | Default | Description                                          |
-| ---------------------- | -------- | ------- | ---------------------------------------------------- |
-| `monitor_id`           | no       |         | same string that was supplied to add_room_iq_monitor |
+| Service data attribute | Optional | Default | Description                                              |
+| ---------------------- | -------- | ------- | -------------------------------------------------------- |
+| `monitor_id`           | no       |         | same identifier that was supplied to add_room_iq_monitor |
 
 ### Service `has_room_iq_monitor`
 
-Return True when this zone has any RoomIQ sensor monitors.
+Return True when this zone has any RoomIQ sensor monitors registered.
 
 ## NexiaRoomIQHarmonizer Services
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ You can obtain sensor details in a Nexia Thermostat environment.
 The sensor data loaded during Nexia Home update are often out of date.
 So the Nexia Thermostat Zone service `load_current_sensor_state`
 is provided to load current sensor state into the physical thermostat.
+If you want Nexia Home update to also load current sensor state,
+you can register a monitor via the Nexia Thermostat Zone service `add_room_iq_monitor`.
+
 Many existing thermostat instance services will refresh this sensor data before completing.
 If no such service is desired,
 the Nexia Thermostat service `refresh_thermostat_data` is provided to refresh instance data.
@@ -44,7 +47,33 @@ To help coordinate separate manual actions taken to select active sensors
 you can use the Nexia RoomIQ Harmonizer services `trigger_add_sensor`,
 `trigger_remove_sensor`, `request_pending`, `async_shutdown`.
 
-## Attributes
+## NexiaHome Attributes
+
+The following attribute is provided by the Nexia Home:
+`log_response`
+
+### Attribute `log_response`
+
+An instance attribute of NexiaHome that controls logging http response text.
+This can be True or False.
+It is initialized to True and you can change it to False
+when you want to stop collecting http response text in your logs.
+
+| Attribute type | Default | Description              |
+| -------------- | ------- | ------------------------ |
+| Boolean        | True    | response logging control |
+
+## NexiaHome Services
+
+The following service is provided by the Nexia Home:
+`any_room_iq_monitors`
+
+### Service `any_room_iq_monitors`
+
+Return True when any RoomIQ sensor monitors are present.
+No arguments are passed to this service.
+
+## Thermostat Attributes
 
 The following attributes are provided by the Nexia Thermostat
 `aux_heat`, `away_mode`, `current_humidity`, `current_temperature`,
@@ -294,23 +323,7 @@ The status of the zone, such as 'Cooling', or 'Heating"
 | -------------- | ----------- |
 | String         | zone status |
 
-## NexiaHome Attributes
-
-The following attribute is provided by the Nexia Home:
-`log_response`
-
-### Attribute `log_response`
-
-An instance attribute of NexiaHome that controls logging http response text.
-This can be True or False.
-It is initialized to True and you can change it to False
-when you want to stop collecting http response text in your logs.
-
-| Attribute type | Default | Description              |
-| -------------- | ------- | ------------------------ |
-| Boolean        | True    | response logging control |
-
-## Services
+## Thermostat Services
 
 The following `climate` services are provided by the Nexia Thermostat:
 `set_aux_heat`, `set_away_mode`, `set_fan_mode`, `set_hold_mode`, `set_humidity`,
@@ -441,7 +454,8 @@ Part of the `nexia.` services. Sets the humidify setpoint. This is a system-wide
 
 The following services are provided by the Nexia Thermostat Zone:
 `get_sensors`, `get_active_sensor_ids`, `get_sensor_by_id`,
-`select_room_iq_sensors`, `load_current_sensor_state`
+`select_room_iq_sensors`, `load_current_sensor_state`,
+`add_room_iq_monitor`, `remove_room_iq_monitor`, `has_room_iq_monitor`
 
 ### Service `get_sensors`
 
@@ -490,6 +504,31 @@ This service returns a bool indicating if it completed successfully.
 | ---------------------- | -------- | ------- | ---------------------------------------------- |
 | `polling_delay`        | yes      | 5.0     | seconds to wait before each polling attempt    |
 | `max_polls`            | yes      | 8       | maximum number of times to poll for completion |
+
+### Service `add_room_iq_monitor`
+
+Add a RoomIQ sensor monitor to this zone's collection.
+A RoomIQ sensor monitor lets the Nexia library know there is a party
+interested in seeing current states of this zone's RoomIQ sensors.
+If no monitors are added, updates don't load current RoomIQ sensor states.
+
+| Service data attribute | Optional | Default | Description                                           |
+| ---------------------- | -------- | ------- | ----------------------------------------------------- |
+| `monitor_id`           | no       |         | string for the interested party (unique in this zone) |
+
+### Service `remove_room_iq_monitor`
+
+Remove a RoomIQ sensor monitor from this zone's collection.
+This tells the Nexia library the specified party is no longer
+interested in seeing current states of this zone's RoomIQ sensors.
+
+| Service data attribute | Optional | Default | Description                                          |
+| ---------------------- | -------- | ------- | ---------------------------------------------------- |
+| `monitor_id`           | no       |         | same string that was supplied to add_room_iq_monitor |
+
+### Service `has_room_iq_monitor`
+
+Return True when this zone has any RoomIQ sensor monitors.
 
 ## NexiaRoomIQHarmonizer Services
 

--- a/nexia/home.py
+++ b/nexia/home.py
@@ -402,6 +402,21 @@ class NexiaHome:
         await asyncio.sleep(UPDATE_DELAY_SECONDS)
         await self.update()
 
+    def any_room_iq_monitors(self) -> bool:
+        """Return True when any RoomIQ sensor monitors are present."""
+        return bool(self.thermostats) and any(
+            any(zone.has_room_iq_monitor() for zone in therm.zones)
+            for therm in self.thermostats
+        )
+
+    async def _load_current_room_iq_states(self) -> None:
+        """Load the current state of all monitored zones' RoomIQ sensors in parallel."""
+        async with asyncio.TaskGroup() as tg:
+            for therm in self.thermostats:
+                for zone in therm.zones:
+                    if zone.has_room_iq_monitor():
+                        tg.create_task(zone.load_current_sensor_state())
+
     async def update(self, force_update: bool = True) -> dict[str, Any] | None:
         """Updates the nexia status.
         :param force_update: Whether to force the update.
@@ -421,6 +436,8 @@ class NexiaHome:
         if not self.mobile_id:
             # not yet authenticated
             return None
+        if self.any_room_iq_monitors():
+            await self._load_current_room_iq_states()
 
         headers = {}
         if self._last_update_etag:

--- a/nexia/home.py
+++ b/nexia/home.py
@@ -113,7 +113,7 @@ class NexiaHome:
         self.username = username
         self.password = password
         self.house_id = house_id
-        self.mobile_id = None
+        self.mobile_id: int | None = None
         self.brand = brand
         self.login_attempts_left = MAX_LOGIN_ATTEMPTS
         self._state_file = state_file or f"{brand}_config_{self.username}.conf"
@@ -411,11 +411,13 @@ class NexiaHome:
 
     async def _load_current_room_iq_states(self) -> None:
         """Load the current state of all monitored zones' RoomIQ sensors in parallel."""
-        async with asyncio.TaskGroup() as tg:
-            for therm in self.thermostats:
-                for zone in therm.zones:
-                    if zone.has_room_iq_monitor():
-                        tg.create_task(zone.load_current_sensor_state())
+        load_current_sensor_state_coroutines = (
+            zone.load_current_sensor_state()
+            for therm in self.thermostats
+            for zone in therm.zones
+            if zone.has_room_iq_monitor()
+        )
+        await asyncio.gather(*load_current_sensor_state_coroutines)
 
     async def update(self, force_update: bool = True) -> dict[str, Any] | None:
         """Updates the nexia status.
@@ -439,7 +441,7 @@ class NexiaHome:
         if self.any_room_iq_monitors():
             await self._load_current_room_iq_states()
 
-        headers = {}
+        headers: dict[str, str] = {}
         if self._last_update_etag:
             headers["If-None-Match"] = self._last_update_etag
 

--- a/nexia/home.py
+++ b/nexia/home.py
@@ -403,7 +403,7 @@ class NexiaHome:
         await self.update()
 
     def any_room_iq_monitors(self) -> bool:
-        """Return True when any RoomIQ sensor monitors are present."""
+        """Return True when any RoomIQ sensor monitors are registered."""
         return bool(self.thermostats) and any(
             any(zone.has_room_iq_monitor() for zone in therm.zones)
             for therm in self.thermostats
@@ -417,7 +417,18 @@ class NexiaHome:
             for zone in therm.zones
             if zone.has_room_iq_monitor()
         )
-        await asyncio.gather(*load_current_sensor_state_coroutines)
+        results = await asyncio.gather(
+            *load_current_sensor_state_coroutines, return_exceptions=True
+        )
+        for result in results:
+            if isinstance(result, Exception):
+                # stale data beats no data - just log this and continue
+                _LOGGER.exception(
+                    "Failed to load RoomIQ sensor state: Exception %s: %s",
+                    result.__class__.__name__,
+                    str(result),
+                    exc_info=result,
+                )
 
     async def update(self, force_update: bool = True) -> dict[str, Any] | None:
         """Updates the nexia status.
@@ -439,6 +450,7 @@ class NexiaHome:
             # not yet authenticated
             return None
         if self.any_room_iq_monitors():
+            # load current data now so the server is not dealing with stale data
             await self._load_current_room_iq_states()
 
         headers: dict[str, str] = {}

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -131,6 +131,7 @@ class NexiaThermostatZone:
         self._zone_json = zone_json
         self.thermostat = nexia_thermostat
         self.zone_id = make_zone_id(nexia_thermostat, zone_json)
+        self._room_iq_monitors: set[str] = set()
 
     @property
     def API_MOBILE_ZONE_URL(self) -> str:  # pylint: disable=invalid-name
@@ -727,6 +728,29 @@ class NexiaThermostatZone:
 
         _LOGGER.error("Gave up waiting while %s", target)
         return False
+
+    def add_room_iq_monitor(self, monitor_id: str) -> None:
+        """Add a RoomIQ sensor monitor to this zone's collection.
+
+        A RoomIQ sensor monitor lets this library know there is a party
+        interested in seeing current states of this zone's RoomIQ sensors.
+        If no monitors are added, updates don't load current RoomIQ sensor states.
+        :param monitor_id: string for the interested party (unique in this zone)
+        """
+        self._room_iq_monitors.add(monitor_id)
+
+    def remove_room_iq_monitor(self, monitor_id: str) -> None:
+        """Remove a RoomIQ sensor monitor from this zone's collection.
+
+        This tells the Nexia library the specified party is no longer
+        interested in seeing current states of this zone's RoomIQ sensors.
+        :param monitor_id: same string that was supplied to add_room_iq_monitor
+        """
+        self._room_iq_monitors.discard(monitor_id)
+
+    def has_room_iq_monitor(self) -> bool:
+        """Return True when this zone has any RoomIQ sensor monitors."""
+        return bool(self._room_iq_monitors)
 
     def round_temp(self, temperature: float) -> float:
         """Rounds the temperature to the nearest 1/2 degree for C and nearest 1

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -730,26 +730,28 @@ class NexiaThermostatZone:
         return False
 
     def add_room_iq_monitor(self, monitor_id: str) -> None:
-        """Add a RoomIQ sensor monitor to this zone's collection.
+        """Register a subscriber for this zone's RoomIQ sensor state updates.
 
-        A RoomIQ sensor monitor lets this library know there is a party
-        interested in seeing current states of this zone's RoomIQ sensors.
-        If no monitors are added, updates don't load current RoomIQ sensor states.
-        :param monitor_id: string for the interested party (unique in this zone)
+        When at least one monitor is registered, each Nexia Home update will
+        also fetch the current RoomIQ sensor states for this zone, adding
+        5–40 seconds of latency and additional network traffic.
+
+        :param monitor_id: Identifier for the subscriber (unique in this zone).
         """
         self._room_iq_monitors.add(monitor_id)
 
     def remove_room_iq_monitor(self, monitor_id: str) -> None:
-        """Remove a RoomIQ sensor monitor from this zone's collection.
+        """Unregister a subscriber for this zone's RoomIQ sensor state updates.
 
-        This tells the Nexia library the specified party is no longer
-        interested in seeing current states of this zone's RoomIQ sensors.
-        :param monitor_id: same string that was supplied to add_room_iq_monitor
+        This tells the Nexia library the specified subscriber is no longer
+        interested in current states of this zone's RoomIQ sensors.
+
+        :param monitor_id: Same identifier that was supplied to add_room_iq_monitor.
         """
         self._room_iq_monitors.discard(monitor_id)
 
     def has_room_iq_monitor(self) -> bool:
-        """Return True when this zone has any RoomIQ sensor monitors."""
+        """Return True when this zone has any RoomIQ sensor monitors registered."""
         return bool(self._room_iq_monitors)
 
     def round_temp(self, temperature: float) -> float:

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1426,22 +1426,18 @@ async def test_sensor_access(
     assert await zone.load_current_sensor_state(max_polls=0) is False
 
     # execute normal code path
+    polling_url = "https://www.mynexia.com/backstage/announcements/6a31e745716789b84603036489fe8d1e35ca80fa5dd381e5"
     mock_aioresponse.post(
         "https://www.mynexia.com/mobile/xxl_zones/85034552/request_current_sensor_state",
         payload={
             "success": True,
             "error": None,
-            "result": {
-                "polling_path": "https://www.mynexia.com/backstage/announcements/6a31e745716789b84603036489fe8d1e35ca80fa5dd381e5"
-            },
+            "result": {"polling_path": polling_url},
         },
     )
+    mock_aioresponse.get(polling_url, body=b"null")
     mock_aioresponse.get(
-        "https://www.mynexia.com/backstage/announcements/6a31e745716789b84603036489fe8d1e35ca80fa5dd381e5",
-        body=b"null",
-    )
-    mock_aioresponse.get(
-        "https://www.mynexia.com/backstage/announcements/6a31e745716789b84603036489fe8d1e35ca80fa5dd381e5",
+        polling_url,
         payload={
             "status": "success, altered to enhance test coverage",
             "options": {},
@@ -1510,6 +1506,45 @@ async def test_sensor_access(
     assert persist_file.exists() is True
     persist_file.unlink()
     assert persist_file.exists() is False
+
+
+async def test_room_iq_sensor_monitor(
+    aiohttp_session: aiohttp.ClientSession, mock_aioresponse: aiointercept
+) -> None:
+    """Test RoomIQ sensor monitor function."""
+    nexia = NexiaHome(aiohttp_session, house_id=2582941)
+    nexia.mobile_id = 5400000
+
+    mock_aioresponse.get(
+        "https://www.mynexia.com/mobile/houses/2582941",
+        body=await load_fixture("sensors_xl1050_house.json"),
+        repeat=True,
+    )
+
+    with patch(
+        "nexia.zone.NexiaThermostatZone.load_current_sensor_state", return_value=True
+    ) as mock_load_current_sensor_state:
+        # Test that we don't update current sensor state with no added monitors
+        assert nexia.any_room_iq_monitors() is False
+        assert await nexia.update() is not None
+        mock_load_current_sensor_state.assert_not_awaited()
+
+        # Add some monitors
+        zone = nexia.get_thermostat_by_id(5378307).get_zone_by_id(85034552)
+        zone.add_room_iq_monitor("sensor.upstairs_roomiq_battery")
+        zone.add_room_iq_monitor("sensor.center_roomiq_temperature")
+        assert nexia.any_room_iq_monitors() is True
+        # Remove one
+        zone.remove_room_iq_monitor("sensor.upstairs_roomiq_battery")
+        assert nexia.any_room_iq_monitors() is True
+
+        # Make sure we update current sensor state now
+        assert await nexia.update() is not None
+        mock_load_current_sensor_state.assert_awaited_once_with()
+
+    # Remove the last one
+    zone.remove_room_iq_monitor("sensor.center_roomiq_temperature")
+    assert nexia.any_room_iq_monitors() is False
 
 
 async def test_clamp_to_predefined_values() -> None:

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1542,6 +1542,10 @@ async def test_room_iq_sensor_monitor(
         assert await nexia.update() is not None
         mock_load_current_sensor_state.assert_awaited_once_with()
 
+        # Force exception path
+        mock_load_current_sensor_state.side_effect = aiohttp.ServerTimeoutError
+        assert await nexia.update() is not None
+
     # Remove the last one
     zone.remove_room_iq_monitor("sensor.center_roomiq_temperature")
     assert nexia.any_room_iq_monitors() is False


### PR DESCRIPTION
### Proposed change
Add feature that maintains a registry of parties interested in seeing current states of a zone's RoomIQ sensors.
### Why
This change provides a way for a caller to offload some complexity to this library.
With this change the caller can register its interest in seeing current states of a zone's RoomIQ sensors. The library then handles obtaining this current data at appropriate times.
### How
Adding 3 services to Nexia Thermostat Zone:
1. `add_room_iq_monitor`,
2. `remove_room_iq_monitor` and
3. `has_room_iq_monitor`

and one servicre to Nexia Home:
1. `any_room_iq_monitors`